### PR TITLE
Use Keychain for Session Storage, Session Bug Fix

### DIFF
--- a/Sources/GoTrue/AuthChangeEvent.swift
+++ b/Sources/GoTrue/AuthChangeEvent.swift
@@ -1,4 +1,3 @@
-
 public enum AuthChangeEvent: String {
     case signedIn = "SIGNED_IN"
     case signedOut = "SIGNED_OUT"

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -138,7 +138,7 @@ public class GoTrueClient {
                 self.notifyAllStateChangeListeners(.userUpdated)
                 self.currentSession?.user = user
                 if let currentSession = self.currentSession {
-                    sessionManager.saveSession(currentSession)
+                    self.sessionManager.saveSession(currentSession)
                 }
                 completion(.success(user))
             case let .failure(error):
@@ -227,7 +227,9 @@ public class GoTrueClient {
         }
 
         sessionManager.removeSession()
+        currentSession = nil
         notifyAllStateChangeListeners(.signedOut)
+        
         api.signOut(accessToken: accessToken) { result in
             completion(result)
         }
@@ -266,7 +268,7 @@ extension GoTrueClient {
 
     public func onAuthStateChange() -> AsyncStream<(AuthChangeEvent, Session?)> {
         AsyncStream { continuation in
-            let subscription = onAuthStateChange { event, session in
+            _ = onAuthStateChange { event, session in
                 continuation.yield((event, session))
             }
 

--- a/Sources/GoTrue/GoTrueKeychain.swift
+++ b/Sources/GoTrue/GoTrueKeychain.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Security
+
+class GoTrueKeychain {
+    // Parameters for storage, set with sensible defaults in `init`
+    var serviceName: String
+    var accessGroup: String?
+    
+    // Private constants
+    private let key: Data = "supabase_session_key".data(using: .utf8)!
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    
+    init(serviceName: String? = nil, accessGroup: String? = nil) {
+        self.serviceName = serviceName ?? "supabase.gotrue.swift"
+        self.accessGroup = accessGroup
+    }
+    
+    func storeSession(_ session: Session) throws {
+        let data = try encoder.encode(session)
+        storeData(data)
+    }
+    
+    func getSession() throws -> Session? {
+        if let encodedData = getData() {
+            return try decoder.decode(Session.self, from: encodedData)
+        } else {
+            return nil
+        }
+    }
+    
+    func deleteSession() {
+        deleteData()
+    }
+}
+
+extension GoTrueKeychain {
+    
+    /// Stores given data in the keychain.
+    /// - Parameter data: Data to store
+    /// - Returns: Boolean, `true` if the operation was successul.
+    @discardableResult
+    private func storeData(_ data: Data) -> Bool {
+        var query = setUpQueryDictionary()
+        query[kSecValueData] = data
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        
+        if status == errSecSuccess {
+            return true
+        } else if status == errSecDuplicateItem {
+            return updateData(data)
+        } else {
+            return false
+        }
+    }
+    
+    /// Updates a keychain item, used when `storeData` fails with a duplicate item.
+    /// - Parameter data: Data to store.
+    /// - Returns: Boolean, `true` if the operation succeeded.
+    @discardableResult
+    private func updateData(_ data: Data) -> Bool {
+        let query = setUpQueryDictionary()
+        let updateDictionary: CFDictionary = [kSecValueData: data] as CFDictionary
+        
+        let status = SecItemUpdate(query as CFDictionary, updateDictionary)
+        
+        return status == errSecSuccess
+    }
+    
+    /// Gets any available data in the keychain.
+    /// - Returns: Boolean, `true` if the operation succeeded.
+    @discardableResult
+    private func getData() -> Data? {
+        var query = setUpQueryDictionary()
+        query[kSecMatchLimit] = kSecMatchLimitOne // Limit results to one
+        query[kSecReturnData] = kCFBooleanTrue
+        
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        
+        return (status == errSecSuccess) ? (result as? Data) : nil
+    }
+    
+    /// Deletes the stored session from the keychain.
+    /// - Returns: Boolean, `true` if the operation succeeded.
+    @discardableResult
+    private func deleteData() -> Bool {
+        let query = setUpQueryDictionary()
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess
+    }
+    
+    /// Generates a query dictionary for keychain operations.
+    /// - Returns: `[CFString: Any]` that can be type-casted to a `CFDictionary`.
+    /// By default sets these parameters:
+    ///  - Class = Generic Password
+    ///  - Accessibility = After first unlock this device only
+    ///  Customizable parameters (customized through class initialization):
+    ///  - Service Name
+    ///  - Access Group
+    ///  Static Parameters
+    ///  - Storage Key
+    private func setUpQueryDictionary() -> [CFString: Any] {
+        var dictionary: [CFString: Any] = [
+            kSecAttrGeneric: key,
+            kSecAttrAccount: key,
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: serviceName,
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+        
+        if let accessGroup = accessGroup {
+            dictionary[kSecAttrAccessGroup] = accessGroup
+        }
+        
+        return dictionary
+    }
+}

--- a/Sources/GoTrue/GoTrueKeychain.swift
+++ b/Sources/GoTrue/GoTrueKeychain.swift
@@ -22,10 +22,8 @@ class GoTrueKeychain {
     }
     
     func getSession() throws -> Session? {
-        if let encodedData = getData() {
-            return try decoder.decode(Session.self, from: encodedData)
-        } else {
-            return nil
+        try getData().map {
+            try decoder.decode(Session.self, from: $0)
         }
     }
     

--- a/Sources/GoTrue/GoTrueSessionManager.swift
+++ b/Sources/GoTrue/GoTrueSessionManager.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// A class for managing the storage of the user's session. Also handles updating from any legacy storage.
+class GoTrueSessionManager {
+    private let keychain: GoTrueKeychain
+    
+    init(serviceName: String? = nil, accessGroup: String? = nil) {
+        keychain = GoTrueKeychain(serviceName: serviceName, accessGroup: accessGroup)
+    }
+    
+    /// Checks for any `UserDefaults` stored session and migrates it to the keychain for improved security.
+    public func checkForOldStorage() {
+        if let session = UserDefaults.standard.value(Session.self, forKey: "\(GoTrueConstants.defaultStorageKey).session") {
+            saveSession(session)
+            UserDefaults.standard.removeObject(forKey: "\(GoTrueConstants.defaultStorageKey).session")
+        }
+    }
+    
+    /// Fetches any available session from the Keychain
+    public func getSession() -> Session? {
+        return try? keychain.getSession()
+    }
+    
+    public func saveSession(_ session: Session) {
+        try? keychain.storeSession(session)
+    }
+    
+    public func removeSession() {
+        keychain.deleteSession()
+    }
+    
+}


### PR DESCRIPTION
# What does this PR Do?

- Moves session storage away from UserDefaults and into the more secure Keychain.
- Fixes a bug where, after signing out, the `user` and `session` variables still held the old data from before signing out.

# Why?

The Keychain should be used to store user data such as refresh tokens, access tokens and emails. When this data is stored in `UserDefaults` it can be stolen _quite_ easily by just reading the public `plist` file that UserDefaults creates. This can lead to bad actors stealing user tokens with ease and using that to steal private data. This is not good.

Storing this data in the Keychain is the safe alternative. `GoTrueKeychain` implements the necessary functions for storing and deleting session data from the Keychain, and `GoTrueSessionManager` manages migrating from `UserDefaults` to Keychain, and fetching and storing session data using the keychain wrapper.

The Keychain wrapper stores the session data in a service called "supabase.gotrue.swift" so as to separate the keys stored by supabase and the keys stored by the app's developer. 

My Keychain implementation also allows for developers to set an `accessGroup` to store the session data in, which will allow developers to share auth state between the app and extensions such as widgets or Siri Shortcuts. By default the access group is not set and is stored in the default Keychain. 

> One thing that Supabase could implement that Firebase lacks on iOS is the ability to migrate from one keychain access group to another. Possibly with an API like: `auth.migrateFrom(keychainGroup, to)` but that can come later. This implementation does allow for flexibility like that in the future.