### PR TITLE
Refresh session object after "refreshSession" method is called

### DIFF
--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -181,7 +181,7 @@ public class GoTrueClient {
         }
     }
 
-    func saveSession(session: Session) {
+    public func saveSession(session: Session) {
         currentSession = session
 
         sessionManager.saveSession(session)

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -215,7 +215,16 @@ public class GoTrueClient {
             completion(.failure(GoTrueError(message: "Not logged in.")))
             return
         }
-        callRefreshToken(refreshToken: refreshToken) { result in
+        callRefreshToken(refreshToken: refreshToken) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case let .success(session):
+                self.saveSession(session: session)
+            case let .failure(error):
+                print(error.localizedDescription)
+            }
+
             completion(result)
         }
     }

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -181,7 +181,7 @@ public class GoTrueClient {
         }
     }
 
-    public func saveSession(session: Session) {
+    func saveSession(session: Session) {
         currentSession = session
 
         sessionManager.saveSession(session)
@@ -216,11 +216,9 @@ public class GoTrueClient {
             return
         }
         callRefreshToken(refreshToken: refreshToken) { [weak self] result in
-            guard let self = self else { return }
-
             switch result {
             case let .success(session):
-                self.saveSession(session: session)
+                self?.saveSession(session: session)
             case let .failure(error):
                 print(error.localizedDescription)
             }


### PR DESCRIPTION
Hello 👋

The `refreshSession` method is not really refreshing the session. It is calling the endpoint to refresh the session but the session object is not updated when the response is received. 

There is no way to update the session object when you force refresh the token using the `refreshSession` method. 

In this PR I also updated the session object when the refresh is made.

Thanks,
Cosmin