### PR TITLE
Linux compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,12 @@ import PackageDescription
 
 let package = Package(
   name: "GoTrue",
-  platforms: [.iOS(.v11)],
+  platforms: [
+    .macOS(.v10_15),
+    .iOS(.v11),
+    .tvOS(.v11),
+    .watchOS(.v3),
+  ],
   products: [
     .library(name: "GoTrue", targets: ["GoTrue"])
   ],

--- a/Sources/GoTrue/GoTrueApi.swift
+++ b/Sources/GoTrue/GoTrueApi.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 class GoTrueApi {
   var url: String

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public typealias AuthStateChangeCallback = (_ event: AuthChangeEvent, _ session: Session?) -> Void
 


### PR DESCRIPTION
Add `FoundationNetworking` if available.
This is allowing Linux platforms to compile the framework, since the migration of URL-related function to the `FoundationNetworking` framework.
Update the `Package.swift` to accept the same platforms as `supabase-swift`.