### PR TITLE
Extract session from fragment instead of query

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+      
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: swift build -v
+    - name: Run tests
+      run: swift test -v

--- a/Sources/GoTrue/Extensions.swift
+++ b/Sources/GoTrue/Extensions.swift
@@ -14,10 +14,10 @@ extension SessionOrUser {
 }
 
 extension Request {
-  func withAuthoriztion(_ token: String) -> Self {
+  func withAuthoriztion(_ token: String, type: String = "Bearer") -> Self {
     var copy = self
     var headers = copy.headers ?? [:]
-    headers["Authorization"] = "Bearer \(token)"
+    headers["Authorization"] = "\(type) \(token)"
     copy.headers = headers
     return copy
   }

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -127,10 +127,6 @@ public final class GoTrueClient {
       ("provider", provider.rawValue)
     ]
 
-    var queryItems: [URLQueryItem] = [
-      URLQueryItem(name: "provider", value: provider.rawValue)
-    ]
-
     if let scopes = scopes {
       fragments.append(("scopes", scopes))
     }

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -177,6 +177,7 @@ public final class GoTrueClient {
     let fragments = (components.fragment ?? "")
       .split(separator: "&")
       .map { $0.split(separator: "=") }
+      .filter { $0.count == 2 }
       .map { (name: String($0[0]), value: String($0[1])) }
 
     if let errorDescription = fragments.first(where: { $0.name == "error_description" })?.value {

--- a/Sources/GoTrue/Internal/Helpers.swift
+++ b/Sources/GoTrue/Internal/Helpers.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+func extractParams(from fragment: String) -> [(name: String, value: String)] {
+  let components =
+    fragment
+    .split(separator: "&")
+    .map { $0.split(separator: "=") }
+
+  return
+    components
+    .compactMap {
+      $0.count == 2
+        ? (name: String($0[0]), value: String($0[1]))
+        : nil
+    }
+}

--- a/Tests/GoTrueTests/GoTrueTests.swift
+++ b/Tests/GoTrueTests/GoTrueTests.swift
@@ -67,6 +67,21 @@ final class GoTrueTests: XCTestCase {
     )
     XCTAssertEqual(session, expectedSession)
   }
+
+  func testSessionFromURLWithMissingComponent() async {
+    let url = URL(
+      string:
+        "https://dummy-url.com/callback#access_token=accesstoken&expires_in=60&refresh_token=refreshtoken"
+    )!
+
+    do {
+      _ = try await sut.session(from: url)
+    } catch let error as URLError {
+      XCTAssertEqual(error.code, .badURL)
+    } catch {
+      XCTFail("Unexpected error thrown: \(error.localizedDescription)")
+    }
+  }
 }
 
 let sessionJSON = """

--- a/Tests/GoTrueTests/GoTrueTests.swift
+++ b/Tests/GoTrueTests/GoTrueTests.swift
@@ -37,7 +37,7 @@ final class GoTrueTests: XCTestCase {
       url,
       URL(
         string:
-          "http://localhost:54321/auth/v1/authorize?provider=github&scopes=read,write&redirect_to=https://dummy-url.com/redirect"
+          "http://localhost:54321/auth/v1/authorize#provider=github&scopes=read,write&redirect_to=https://dummy-url.com/redirect"
       )!
     )
   }
@@ -45,7 +45,7 @@ final class GoTrueTests: XCTestCase {
   func testSessionFromURL() async throws {
     let url = URL(
       string:
-        "https://dummy-url.com/callback?access_token=accesstoken&expires_in=60&refresh_token=refreshtoken&token_type=bearer"
+        "https://dummy-url.com/callback#access_token=accesstoken&expires_in=60&refresh_token=refreshtoken&token_type=bearer"
     )!
 
     var mock = Mock.get(path: "user", json: "user")

--- a/Tests/GoTrueTests/GoTrueTests.swift
+++ b/Tests/GoTrueTests/GoTrueTests.swift
@@ -32,12 +32,14 @@ final class GoTrueTests: XCTestCase {
   func testSignInWithProvider() throws {
     let url = try sut.signIn(
       provider: .github, scopes: "read,write",
-      redirectURL: URL(string: "https://dummy-url.com/redirect")!)
+      redirectURL: URL(string: "https://dummy-url.com/redirect")!,
+      queryParams: [("extra_key", "extra_value")]
+    )
     XCTAssertEqual(
       url,
       URL(
         string:
-          "http://localhost:54321/auth/v1/authorize#provider=github&scopes=read,write&redirect_to=https://dummy-url.com/redirect"
+          "http://localhost:54321/auth/v1/authorize?provider=github&scopes=read,write&redirect_to=https://dummy-url.com/redirect&extra_key=extra_value"
       )!
     )
   }


### PR DESCRIPTION
Fixes #22 

When signing in with a provider the session is returned in the `fragment` component of the URL instead of `query`, this PR fixes this by extracting the session components from the `fragment`.