### PR TITLE
Make it easier to call session start for Partner login

### DIFF
--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -147,6 +147,7 @@ public final class GoTrueClient {
     return url
   }
 
+  @discardableResult
   public func refreshSession(refreshToken: String) async throws -> Session {
     do {
       let session = try await Current.client.send(


### PR DESCRIPTION
I'd imagine it to be fairly common that when a user of `gotrue-swift` wants to complete the Partner sign in process and start a session, they don't care about the `Session` that is created.