### PR TITLE
Trigger signout event even with API call fails.

### DIFF
--- a/Examples/Shared/ExamplesApp.swift
+++ b/Examples/Shared/ExamplesApp.swift
@@ -5,23 +5,23 @@
 //  Created by Guilherme Souza on 28/06/22.
 //
 
-import SwiftUI
 import GoTrue
+import SwiftUI
 
 @main
 struct ExamplesApp: App {
-    var body: some Scene {
-        WindowGroup {
-            NavigationView {
-                List {
-                    NavigationLink("Sign in with Google") {
-                        SignInWithGoogleExampleView()
-                    }
-                }
-                .navigationTitle("Examples")
-            }
+  var body: some Scene {
+    WindowGroup {
+      NavigationView {
+        List {
+          NavigationLink("Sign in with Google") {
+            SignInWithGoogleExampleView()
+          }
         }
+        .navigationTitle("Examples")
+      }
     }
+  }
 }
 
 /// Global GoTrueClient instance.

--- a/Examples/Shared/SignInWithGoogleExampleView.swift
+++ b/Examples/Shared/SignInWithGoogleExampleView.swift
@@ -5,65 +5,65 @@
 //  Created by Guilherme Souza on 28/06/22.
 //
 
-import SwiftUI
 import GoTrue
+import SwiftUI
 
 struct SignInWithGoogleExampleView: View {
-    @State var user: User?
+  @State var user: User?
 
-    @ViewBuilder
-    var body: some View {
-        if let user = user {
-            Form {
-                Section {
-                    Text(stringfy(user))
-                        .multilineTextAlignment(.leading)
-                }
+  @ViewBuilder
+  var body: some View {
+    if let user = user {
+      Form {
+        Section {
+          Text(stringfy(user))
+            .multilineTextAlignment(.leading)
+        }
 
-                Section {
-                    Button("Sign out") {
-                        Task {
-                            try await gotrue.signOut()
-                            self.user = nil
-                        }
-                    }
-                }
+        Section {
+          Button("Sign out") {
+            Task {
+              try await gotrue.signOut()
+              self.user = nil
             }
-        } else {
-            Button("Sign in with Google", action: signInWithGoogleTapped)
-                .buttonStyle(.borderedProminent)
-                .padding()
-                .onOpenURL { url in
-                    Task {
-                        try await gotrue.session(from: url)
-                        self.user = gotrue.session?.user
-                    }
-                }
-                .onAppear {
-                    self.user = gotrue.session?.user
-                }
+          }
+        }
+      }
+    } else {
+      Button("Sign in with Google", action: signInWithGoogleTapped)
+        .buttonStyle(.borderedProminent)
+        .padding()
+        .onOpenURL { url in
+          Task {
+            try await gotrue.session(from: url)
+            self.user = gotrue.session?.user
+          }
+        }
+        .onAppear {
+          self.user = gotrue.session?.user
         }
     }
+  }
 
-    func signInWithGoogleTapped() {
-        do {
-            let url = try gotrue.signIn(provider: .google)
-            UIApplication.shared.open(url)
-        } catch {
-            print("Error sign in with google", error)
-        }
+  func signInWithGoogleTapped() {
+    do {
+      let url = try gotrue.signIn(provider: .google)
+      UIApplication.shared.open(url)
+    } catch {
+      print("Error sign in with google", error)
     }
+  }
 }
 
 func stringfy<T: Encodable>(_ value: T) -> String {
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    let data = try! encoder.encode(value)
-    return String(data: data, encoding: .utf8)!
+  let encoder = JSONEncoder()
+  encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+  let data = try! encoder.encode(value)
+  return String(data: data, encoding: .utf8)!
 }
 
 struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        SignInWithGoogleExampleView()
-    }
+  static var previews: some View {
+    SignInWithGoogleExampleView()
+  }
 }

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -221,10 +221,10 @@ public final class GoTrueClient {
   }
 
   public func signOut() async throws {
+    defer { authEventChangeSubject.send(.signedOut) }
     let session = try await Current.sessionManager.session()
-    try await Current.client.send(Paths.logout.post.withAuthoriztion(session.accessToken)).value
     await Current.sessionManager.remove()
-    authEventChangeSubject.send(.signedOut)
+    try await Current.client.send(Paths.logout.post.withAuthoriztion(session.accessToken)).value
   }
 
   @discardableResult

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -220,7 +220,7 @@ public final class GoTrueClient {
     return session
   }
 
-  /// Calling this method will remove the logged in user and erase the tokens storad on local storage and invalidate the token on the API. It also will trigger a ``AuthChangeEvent.signedOut`` event.
+  /// Calling this method will remove the logged in user and erase the tokens stored on local storage and invalidate the token on the API. It also will trigger a ``AuthChangeEvent.signedOut`` event.
   public func signOut() async throws {
     defer { authEventChangeSubject.send(.signedOut) }
 

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -220,11 +220,16 @@ public final class GoTrueClient {
     return session
   }
 
+  /// Calling this method will remove the logged in user and erase the tokens storad on local storage and invalidate the token on the API. It also will trigger a ``AuthChangeEvent.signedOut`` event.
   public func signOut() async throws {
     defer { authEventChangeSubject.send(.signedOut) }
-    let session = try await Current.sessionManager.session()
+
+    let session = try? await Current.sessionManager.session()
     await Current.sessionManager.remove()
-    try await Current.client.send(Paths.logout.post.withAuthoriztion(session.accessToken)).value
+
+    if let session = session {
+      try await Current.client.send(Paths.logout.post.withAuthoriztion(session.accessToken)).value
+    }
   }
 
   @discardableResult


### PR DESCRIPTION
When signing out, the client first performs the API call for invalidating the token and then erase the local storage and trigger the `SIGNED_OUT` event.

I've changed things for erasing local storage first and triggering the event always, no matter if the API call succeeds or not.