### PR TITLE
Make GoTrue.AnyJSON.value public so it can be accessed by callers.

### DIFF
--- a/Sources/GoTrue/Generated/Entities.swift
+++ b/Sources/GoTrue/Generated/Entities.swift
@@ -10,7 +10,7 @@ public enum AnyJSON: Equatable, Codable {
   case array([AnyJSON])
   case bool(Bool)
 
-  var value: Any {
+  public var value: Any {
     switch self {
     case let .string(string): return string
     case let .number(double): return double


### PR DESCRIPTION
## What kind of change does this PR introduce?
Enable access to value of GoTrue.AnyJSON

## What is the current behavior?
GoTrue.AnyJSON.value is not public and therefore internal and inaccessible.
See https://github.com/orgs/supabase/discussions/13209

## What is the new behavior?
GoTrue.AnyJSON.value is public and therefore accessible to application code.

## Additional context
Let me know if I have the wrong end of the stick here, relatively new to Swift.
I did notice that grsouza's version of AnyJSON makes value public too.
