### PR TITLE
Added Identifiable to user

### DIFF
--- a/Sources/GoTrue/Generated/Entities.swift
+++ b/Sources/GoTrue/Generated/Entities.swift
@@ -215,7 +215,7 @@ public struct Session: Codable, Equatable {
   }
 }
 
-public struct User: Codable, Equatable {
+public struct User: Codable, Equatable, Identifiable {
   public var id: UUID
   public var appMetadata: [String: AnyJSON]
   public var userMetadata: [String: AnyJSON]


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Adds `Identifiable` to the `User` entity, which is more inline with
typical `swift` types.

## Additional context

This allows for better developer experience when building on top of
some of the `supabase-community` swift tools, such as using the
user's `id` for database columns without the need to specify our own
custom wrapper type for a `User` entity.

Another (although opinionated) approach would be to use a `Tagged` id,
using [swift-tagged](https://github.com/pointfreeco/swift-tagged.git), so
that you can't pass id's of a non-`User` type.
