### PR TITLE
fix: id_token required

### DIFF
--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -305,7 +305,7 @@ public struct OpenIDConnectCredentials: Codable, Hashable {
   public var provider: Provider?
 
   /// ID token issued by Apple or Google.
-  public var token: String
+  public var idToken: String
 
   /// If the ID token contains a `nonce`, then the hash of this value is compared to the value in
   /// the ID token.
@@ -316,19 +316,19 @@ public struct OpenIDConnectCredentials: Codable, Hashable {
 
   public init(
     provider: Provider? = nil,
-    token: String,
+    idToken: String,
     nonce: String? = nil,
     gotrueMetaSecurity: GoTrueMetaSecurity? = nil
   ) {
     self.provider = provider
-    self.token = token
+    self.idToken = idToken
     self.nonce = nonce
     self.gotrueMetaSecurity = gotrueMetaSecurity
   }
 
   public enum CodingKeys: String, CodingKey {
     case provider
-    case token = "id_token"
+    case idToken = "id_token"
     case nonce
     case gotrueMetaSecurity = "gotrue_meta_security"
   }

--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -328,7 +328,7 @@ public struct OpenIDConnectCredentials: Codable, Hashable {
 
   public enum CodingKeys: String, CodingKey {
     case provider
-    case token
+    case token = "id_token"
     case nonce
     case gotrueMetaSecurity = "gotrue_meta_security"
   }

--- a/Tests/GoTrueTests/GoTrueTests.swift
+++ b/Tests/GoTrueTests/GoTrueTests.swift
@@ -63,7 +63,7 @@ final class GoTrueTests: XCTestCase {
       ).register()
 
       let session = try await sut
-        .signInWithIdToken(credentials: OpenIDConnectCredentials(token: "dummy-token-1234"))
+        .signInWithIdToken(credentials: OpenIDConnectCredentials(idToken: "dummy-token-1234"))
       XCTAssertEqual(session.user.email, "guilherme@binaryscraping.co")
     }
   #endif


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

Getting error 
```json
{
  "error": "invalid request",
  "error_description": "id_token required"
}
```

## What is the current behavior?

#49 

## What is the new behavior?

Issue is fixed because the token is properly encoded as `id_token` as required by the endpoint.

## Additional context

I have not tested this for `.google` (only for `.apple`) but I assume there shouldn't be any issues. I'm also not sure what issues this encoding will cascade to.

CC: @grsouza 