### PR TITLE
Fix: AnyJSON support null values

### DIFF
--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -6,14 +6,16 @@ public enum AnyJSON: Hashable, Codable, Sendable {
   case object([String: AnyJSON])
   case array([AnyJSON])
   case bool(Bool)
+  case null
 
-  public var value: Any {
+  public var value: Any? {
     switch self {
     case let .string(string): return string
     case let .number(double): return double
     case let .object(dictionary): return dictionary
     case let .array(array): return array
     case let .bool(bool): return bool
+    case .null: return nil
     }
   }
 
@@ -25,6 +27,7 @@ public enum AnyJSON: Hashable, Codable, Sendable {
     case let .string(string): try container.encode(string)
     case let .number(number): try container.encode(number)
     case let .bool(bool): try container.encode(bool)
+    case .null: try container.encodeNil()
     }
   }
 
@@ -40,6 +43,8 @@ public enum AnyJSON: Hashable, Codable, Sendable {
       self = .bool(bool)
     } else if let number = try? container.decode(Double.self) {
       self = .number(number)
+    } else if container.decodeNil() {
+        self = .null
     } else {
       throw DecodingError.dataCorrupted(
         .init(codingPath: decoder.codingPath, debugDescription: "Invalid JSON value.")
@@ -154,8 +159,8 @@ public struct Session: Codable, Hashable, Sendable {
 
 public struct User: Codable, Hashable, Identifiable, Sendable {
   public var id: UUID
-  public var appMetadata: [String: AnyJSON?]
-  public var userMetadata: [String: AnyJSON?]
+  public var appMetadata: [String: AnyJSON]
+  public var userMetadata: [String: AnyJSON]
   public var aud: String
   public var confirmationSentAt: Date?
   public var recoverySentAt: Date?
@@ -176,8 +181,8 @@ public struct User: Codable, Hashable, Identifiable, Sendable {
 
   public init(
     id: UUID,
-    appMetadata: [String: AnyJSON?],
-    userMetadata: [String: AnyJSON?],
+    appMetadata: [String: AnyJSON],
+    userMetadata: [String: AnyJSON],
     aud: String,
     confirmationSentAt: Date? = nil,
     recoverySentAt: Date? = nil,

--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -154,8 +154,8 @@ public struct Session: Codable, Hashable, Sendable {
 
 public struct User: Codable, Hashable, Identifiable, Sendable {
   public var id: UUID
-  public var appMetadata: [String: AnyJSON]
-  public var userMetadata: [String: AnyJSON]
+  public var appMetadata: [String: AnyJSON?]
+  public var userMetadata: [String: AnyJSON?]
   public var aud: String
   public var confirmationSentAt: Date?
   public var recoverySentAt: Date?
@@ -176,8 +176,8 @@ public struct User: Codable, Hashable, Identifiable, Sendable {
 
   public init(
     id: UUID,
-    appMetadata: [String: AnyJSON],
-    userMetadata: [String: AnyJSON],
+    appMetadata: [String: AnyJSON?],
+    userMetadata: [String: AnyJSON?],
     aud: String,
     confirmationSentAt: Date? = nil,
     recoverySentAt: Date? = nil,

--- a/Tests/GoTrueTests/GoTrueTests.swift
+++ b/Tests/GoTrueTests/GoTrueTests.swift
@@ -37,6 +37,12 @@ final class GoTrueTests: XCTestCase {
     $0.sessionConfiguration.protocolClasses = [MockingURLProtocol.self]
   }
 
+  func testDecodeUser() {
+    XCTAssertNoThrow(
+      try JSONDecoder.goTrue.decode(User.self, from: json(named: "user"))
+    )
+  }
+
   func testDecodeSessionOrUser() {
     XCTAssertNoThrow(
       try JSONDecoder.goTrue.decode(

--- a/Tests/GoTrueTests/Resources/user.json
+++ b/Tests/GoTrueTests/Resources/user.json
@@ -11,7 +11,9 @@
       "email"
     ]
   },
-  "user_metadata": {},
+  "user_metadata": {
+    "referrer_id": null
+  },
   "identities": [
     {
       "id": "859f402d-b3de-4105-a1b9-932836d9193b",


### PR DESCRIPTION

## What kind of change does this PR introduce?
Bug fix: change type of User.appMetadata and User.userMetadata from `[String:AnyJSON]` to `[String:AnyJSON?]`.

## What is the current behavior?
Decoding User.appMetadata or User.userMetadata fails when the incoming metadata object has a null value.

## What is the new behavior?
Enables decoding null values in the User.appMetadata or User.userMetadata dictionary

