### PR TITLE
Implemented PKCE Authorization Flow

### DIFF
--- a/Examples/Shared/Sources/ExamplesApp.swift
+++ b/Examples/Shared/Sources/ExamplesApp.swift
@@ -18,7 +18,7 @@ struct ExamplesApp: App {
 }
 
 private enum GoTrueEnvironmentKey: EnvironmentKey {
-  static let defaultValue = GoTrueClient(url: SUPABASE_URL, headers: ["apikey": SUPABASE_API_KEY])
+    static let defaultValue = GoTrueClient(url: SUPABASE_URL, headers: ["apikey": SUPABASE_API_KEY], flowType: .pkce)
 }
 
 extension EnvironmentValues {

--- a/Sources/GoTrue/Endpoints.swift
+++ b/Sources/GoTrue/Endpoints.swift
@@ -38,7 +38,7 @@ extension Paths {
     enum PostRequest: Encodable, Equatable {
       case userCredentials(GoTrue.UserCredentials)
       case openIDConnectCredentials(GoTrue.OpenIDConnectCredentials)
-      case pkceCredentials(GoTrue.PKCEParams)
+      case pkceCredentials(GoTrue.PKCECredentials)
 
       func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()

--- a/Sources/GoTrue/Endpoints.swift
+++ b/Sources/GoTrue/Endpoints.swift
@@ -27,13 +27,6 @@ extension Paths {
       encoder.encode(redirectTo, forKey: "redirect_to")
       return encoder.items
     }
-    
-    private func makePKCEPostQuery() -> [(String, String?)] {
-      let encoder = URLQueryEncoder()
-      encoder.encode(GrantType.pkce, forKey: "grant_type")
-        
-      return encoder.items
-    }
 
     enum GrantType: String, Codable, CaseIterable {
       case password

--- a/Sources/GoTrue/Endpoints.swift
+++ b/Sources/GoTrue/Endpoints.swift
@@ -12,6 +12,12 @@ extension Paths {
   struct Token {
     /// Path: `/token`
     let path: String
+      
+    func post(
+      grantType: GrantType,
+      body: PKCEParams) -> Request<GoTrue.Session> {
+        Request(method: "POST", url: path, query: makePKCEPostQuery(), body: body)
+      }
 
     func post(
       grantType: GrantType,
@@ -27,22 +33,32 @@ extension Paths {
       encoder.encode(redirectTo, forKey: "redirect_to")
       return encoder.items
     }
+    
+    private func makePKCEPostQuery() -> [(String, String?)] {
+      let encoder = URLQueryEncoder()
+      encoder.encode(GrantType.pkce, forKey: "grant_type")
+        
+      return encoder.items
+    }
 
     enum GrantType: String, Codable, CaseIterable {
       case password
       case refreshToken = "refresh_token"
       case idToken = "id_token"
+      case pkce
     }
 
     enum PostRequest: Encodable, Equatable {
       case userCredentials(GoTrue.UserCredentials)
       case openIDConnectCredentials(GoTrue.OpenIDConnectCredentials)
+        case pkceCredentials(GoTrue.PKCEParams)
 
       func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
         case let .userCredentials(value): try container.encode(value)
         case let .openIDConnectCredentials(value): try container.encode(value)
+        case let .pkceCredentials(value): try container.encode(value)
         }
       }
     }

--- a/Sources/GoTrue/Endpoints.swift
+++ b/Sources/GoTrue/Endpoints.swift
@@ -13,13 +13,7 @@ extension Paths {
     /// Path: `/token`
     let path: String
       
-    func post(
-      grantType: GrantType,
-      body: PKCEParams) -> Request<GoTrue.Session> {
-        Request(method: "POST", url: path, query: makePKCEPostQuery(), body: body)
-      }
-
-    func post(
+      func post(
       grantType: GrantType,
       redirectTo: URL? = nil,
       _ body: PostRequest
@@ -51,7 +45,7 @@ extension Paths {
     enum PostRequest: Encodable, Equatable {
       case userCredentials(GoTrue.UserCredentials)
       case openIDConnectCredentials(GoTrue.OpenIDConnectCredentials)
-        case pkceCredentials(GoTrue.PKCEParams)
+      case pkceCredentials(GoTrue.PKCEParams)
 
       func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()

--- a/Sources/GoTrue/Extensions.swift
+++ b/Sources/GoTrue/Extensions.swift
@@ -1,23 +1,47 @@
 import Get
+import Foundation
 
 extension AuthResponse {
-  public var user: User? {
-    if case let .user(user) = self { return user }
-    return nil
-  }
-
-  public var session: Session? {
-    if case let .session(session) = self { return session }
-    return nil
-  }
+    public var user: User? {
+        if case let .user(user) = self { return user }
+        return nil
+    }
+    
+    public var session: Session? {
+        if case let .session(session) = self { return session }
+        return nil
+    }
 }
 
 extension Request {
-  func withAuthorization(_ token: String, type: String = "Bearer") -> Self {
-    var copy = self
-    var headers = copy.headers ?? [:]
-    headers["Authorization"] = "\(type) \(token)"
-    copy.headers = headers
-    return copy
-  }
+    func withAuthorization(_ token: String, type: String = "Bearer") -> Self {
+        var copy = self
+        var headers = copy.headers ?? [:]
+        headers["Authorization"] = "\(type) \(token)"
+        copy.headers = headers
+        return copy
+    }
+}
+
+extension URL {
+    public var queryParameters: [String: String]? {
+        guard
+            let components = URLComponents(url: self, resolvingAgainstBaseURL: true),
+            let queryItems = components.queryItems else { return nil }
+        return queryItems.reduce(into: [String: String]()) { (result, item) in
+            result[item.name] = item.value
+        }
+    }
+}
+
+extension Data {
+    // Returns a base64 encoded string, replacing reserved characters
+    // as per the PKCE spec https://tools.ietf.org/html/rfc7636#section-4.2
+    func pkceBase64EncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+            .trimmingCharacters(in: .whitespaces)
+    }
 }

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -218,6 +218,15 @@ public final class GoTrueClient {
     captchaToken: String? = nil
   ) async throws {
     await env.sessionManager.remove()
+      var codeChallenge: String? = nil
+      var codeChallengeMethod: String? = nil
+      
+      if flowType == .pkce {
+          codeVerifier = PKCE.generateCodeVerifier()
+          codeChallenge = PKCE.generateCodeChallenge(from: codeVerifier)
+          codeChallengeMethod = "S256"
+      }
+      
     try await env.client.send(
       Paths.otp.post(
         redirectTo: redirectTo,
@@ -225,7 +234,9 @@ public final class GoTrueClient {
           email: email,
           createUser: shouldCreateUser,
           data: data,
-          gotrueMetaSecurity: captchaToken.map(GoTrueMetaSecurity.init(captchaToken:))
+          gotrueMetaSecurity: captchaToken.map(GoTrueMetaSecurity.init(captchaToken:)),
+          codeChallenge: codeChallenge,
+          codeChallengeMethod: codeChallengeMethod
         )
       )
     )

--- a/Sources/GoTrue/GoTrueError.swift
+++ b/Sources/GoTrue/GoTrueError.swift
@@ -5,7 +5,7 @@ public enum GoTrueError: LocalizedError, Sendable {
   case malformedJWT
   case sessionNotFound
   case api(APIError)
-  case codeNotFound
+  case pkceCodeNotFound
 
   public struct APIError: Error, Decodable, Sendable {
     public var message: String?
@@ -29,7 +29,7 @@ public enum GoTrueError: LocalizedError, Sendable {
     case .malformedJWT: return "A malformed JWT received."
     case .sessionNotFound: return "Unable to get a valid session."
     case let .api(error): return error.errorDescription ?? error.message ?? error.msg
-    case .codeNotFound: return "Unable to get a valid code."
+    case .pkceCodeNotFound: return "A valid PKCE code was not found."
     }
   }
 }

--- a/Sources/GoTrue/GoTrueError.swift
+++ b/Sources/GoTrue/GoTrueError.swift
@@ -5,6 +5,7 @@ public enum GoTrueError: LocalizedError, Sendable {
   case malformedJWT
   case sessionNotFound
   case api(APIError)
+  case codeNotFound
 
   public struct APIError: Error, Decodable, Sendable {
     public var message: String?
@@ -28,6 +29,7 @@ public enum GoTrueError: LocalizedError, Sendable {
     case .malformedJWT: return "A malformed JWT received."
     case .sessionNotFound: return "Unable to get a valid session."
     case let .api(error): return error.errorDescription ?? error.message ?? error.msg
+    case .codeNotFound: return "Unable to get a valid code."
     }
   }
 }

--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -561,7 +561,7 @@ enum PKCE {
     static func generateCodeVerifier() -> String {
         var buffer = [UInt8](repeating: 0, count: 64)
         _ = SecRandomCopyBytes(kSecRandomDefault, buffer.count, &buffer)
-        return Data(buffer).base64EncodedString()
+        return Data(buffer).pkceBase64EncodedString()
     }
     
     static func generateCodeChallenge(from string: String) -> String? {

--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -386,7 +386,7 @@ public struct OTPParams: Codable, Hashable, Sendable {
   public var data: [String: AnyJSON]?
   public var gotrueMetaSecurity: GoTrueMetaSecurity?
   public var codeChallenge: String?
-  public var codeChallengeMethod: String?
+  public var codeChallengeMethod: PKCECodeChallengeMethod?
 
   public init(
     email: String? = nil,
@@ -395,7 +395,7 @@ public struct OTPParams: Codable, Hashable, Sendable {
     data: [String: AnyJSON]? = nil,
     gotrueMetaSecurity: GoTrueMetaSecurity? = nil,
     codeChallenge: String? = nil,
-    codeChallengeMethod: String? = nil
+    codeChallengeMethod: PKCECodeChallengeMethod? = nil
   ) {
     self.email = email
     self.phone = phone
@@ -570,4 +570,8 @@ enum PKCE {
         
         return Data(hashed).pkceBase64EncodedString()
     }
+}
+
+public enum PKCECodeChallengeMethod: String, Codable, Sendable {
+    case sha256 = "S256"
 }

--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -536,7 +536,7 @@ public struct RecoverParams: Codable, Hashable, Sendable {
   }
 }
 
-public struct PKCEParams: Codable, Hashable, Sendable {
+public struct PKCECredentials: Codable, Hashable, Sendable {
     public var authCode: String
     public var codeVerifier: String
     

--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -385,19 +385,25 @@ public struct OTPParams: Codable, Hashable, Sendable {
   public var createUser: Bool
   public var data: [String: AnyJSON]?
   public var gotrueMetaSecurity: GoTrueMetaSecurity?
+  public var codeChallenge: String?
+  public var codeChallengeMethod: String?
 
   public init(
     email: String? = nil,
     phone: String? = nil,
     createUser: Bool? = nil,
     data: [String: AnyJSON]? = nil,
-    gotrueMetaSecurity: GoTrueMetaSecurity? = nil
+    gotrueMetaSecurity: GoTrueMetaSecurity? = nil,
+    codeChallenge: String? = nil,
+    codeChallengeMethod: String? = nil
   ) {
     self.email = email
     self.phone = phone
     self.createUser = createUser ?? true
     self.data = data
     self.gotrueMetaSecurity = gotrueMetaSecurity
+    self.codeChallenge = codeChallenge
+    self.codeChallengeMethod = codeChallengeMethod
   }
 
   public enum CodingKeys: String, CodingKey {
@@ -406,6 +412,8 @@ public struct OTPParams: Codable, Hashable, Sendable {
     case createUser = "create_user"
     case data
     case gotrueMetaSecurity = "gotrue_meta_security"
+    case codeChallenge = "code_challenge"
+    case codeChallengeMethod = "code_challenge_method"
   }
 }
 

--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 
 public enum AnyJSON: Hashable, Codable, Sendable {
   case string(String)
@@ -525,4 +526,40 @@ public struct RecoverParams: Codable, Hashable, Sendable {
     case email
     case gotrueMetaSecurity = "gotrue_meta_security"
   }
+}
+
+public struct PKCEParams: Codable, Hashable, Sendable {
+    public var authCode: String
+    public var codeVerifier: String
+    
+    public init(authCode: String, codeVerifier: String) {
+        self.authCode = authCode
+        self.codeVerifier = codeVerifier
+    }
+    
+    public enum CodingKeys: String, CodingKey {
+        case authCode = "auth_code"
+        case codeVerifier = "code_verifier"
+    }
+}
+
+public enum FlowType {
+    case implicit
+    case pkce
+}
+
+
+enum PKCE {
+    static func generateCodeVerifier() -> String {
+        var buffer = [UInt8](repeating: 0, count: 64)
+        _ = SecRandomCopyBytes(kSecRandomDefault, buffer.count, &buffer)
+        return Data(buffer).base64EncodedString()
+    }
+    
+    static func generateCodeChallenge(from string: String) -> String? {
+        guard let data = string.data(using: .utf8) else { return nil }
+        let hashed = SHA256.hash(data: data)
+        
+        return Data(hashed).pkceBase64EncodedString()
+    }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR consist implementation of PKCE Authorization Flow for `getOAuthSignInURL` & `signInWithOTP` methods.

## What is the current behavior?



## What is the new behavior?

When initializing a client there is a new property called `flowType` which is of type FlowType enum that consist of two types:

- implicit
- pkce

example:
`let client = GoTrueClient(url: "", headers: [:], flowType: .pkce)`

The flowType property has default value of `.implicit`

## Additional context
