### PR TITLE
Update GoTrueClient.swift

### DIFF
--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -167,7 +167,7 @@ public final class GoTrueClient {
 
   /// Allows signing in with an ID token issued by certain supported providers.
   /// The ID token is verified for validity and a new session is established.
-  @_spi(Experimental)
+  
   @discardableResult
   public func signInWithIdToken(credentials: OpenIDConnectCredentials) async throws -> Session {
     try await _signIn(


### PR DESCRIPTION
I removed @_spi (Experimental) protection on signInWithIdToken() to make it usable once again.

I had built an entire app around this allowing sign in with Apple, which is now broken since the experimental protection was added. This is stopping me from releasing the app on TestFlight, which I had hoped to do today.

Please allow this once more - I'd really appreciate it, and am really not sure what to do without it. Thanks.
