### PR TITLE
Removed Provider For Apple Login In getOAuthSignInURL method

### DIFF
--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -167,7 +167,6 @@ public final class GoTrueClient {
 
   /// Allows signing in with an ID token issued by certain supported providers.
   /// The ID token is verified for validity and a new session is established.
-  @_spi(Experimental)
   @discardableResult
   public func signInWithIdToken(credentials: OpenIDConnectCredentials) async throws -> Session {
     try await _signIn(

--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -298,7 +298,6 @@ public struct UserIdentity: Codable, Hashable, Identifiable, Sendable {
 }
 
 public enum Provider: String, Codable, CaseIterable, Sendable {
-  case apple
   case azure
   case bitbucket
   case discord
@@ -340,7 +339,7 @@ public struct OpenIDConnectCredentials: Codable, Hashable, Sendable {
   public var gotrueMetaSecurity: GoTrueMetaSecurity?
 
   public init(
-    provider: Provider? = nil,
+    provider: Provider?,
     idToken: String,
     accessToken: String? = nil,
     nonce: String? = nil,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Removed apple as a Provider from `getOAuthSignInURL` method as well as the experimental label on `signInWithIdToken`

## What is the current behavior?

`signInWithIdToken` was labeled as experimental

## What is the new behavior?

The experimental label on `signInWithIdToken` is removed. Also `.apple` was removed as a Provider for `getOAuthSignInURL` method since we will not provide Apple Sign In with that method.

## Additional context

