### PR TITLE
Remove `@_spi(Experimental)` from `signInWithIdToken`

### DIFF
--- a/Examples/Shared/Sources/SignInWithAppleView.swift
+++ b/Examples/Shared/Sources/SignInWithAppleView.swift
@@ -16,8 +16,9 @@ struct SignInWithAppleView: View {
 
   var body: some View {
     SignInWithAppleButton { request in
-//      self.nonce = sha256(randomString())
-//      request.nonce = nonce
+      let nonce = randomString()
+      self.nonce = nonce
+      request.nonce = sha256(nonce)
       request.requestedScopes = [.email, .fullName]
     } onCompletion: { result in
       Task {
@@ -36,8 +37,8 @@ struct SignInWithAppleView: View {
           try await client.signInWithIdToken(
             credentials: .init(
               provider: .apple,
-              idToken: idToken /* ,
-               nonce: self.nonce */
+              idToken: idToken,
+              nonce: nonce
             )
           )
         } catch {

--- a/Examples/Shared/Sources/SignInWithAppleView.swift
+++ b/Examples/Shared/Sources/SignInWithAppleView.swift
@@ -7,8 +7,8 @@
 
 import AuthenticationServices
 import CryptoKit
+import GoTrue
 import SwiftUI
-@_spi(Experimental) import GoTrue
 
 struct SignInWithAppleView: View {
   @Environment(\.goTrueClient) private var client
@@ -36,8 +36,8 @@ struct SignInWithAppleView: View {
           try await client.signInWithIdToken(
             credentials: .init(
               provider: .apple,
-              idToken: idToken/*,
-              nonce: self.nonce*/
+              idToken: idToken /* ,
+               nonce: self.nonce */
             )
           )
         } catch {

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -167,7 +167,6 @@ public final class GoTrueClient {
 
   /// Allows signing in with an ID token issued by certain supported providers.
   /// The ID token is verified for validity and a new session is established.
-  @_spi(Experimental)
   @discardableResult
   public func signInWithIdToken(credentials: OpenIDConnectCredentials) async throws -> Session {
     try await _signIn(

--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -44,7 +44,7 @@ public enum AnyJSON: Hashable, Codable, Sendable {
     } else if let number = try? container.decode(Double.self) {
       self = .number(number)
     } else if container.decodeNil() {
-        self = .null
+      self = .null
     } else {
       throw DecodingError.dataCorrupted(
         .init(codingPath: decoder.codingPath, debugDescription: "Invalid JSON value.")

--- a/Tests/GoTrueTests/GoTrueTests.swift
+++ b/Tests/GoTrueTests/GoTrueTests.swift
@@ -1,7 +1,7 @@
 import Mocker
 import XCTest
 
-@testable @_spi(Experimental) import GoTrue
+@testable import GoTrue
 
 final class InMemoryLocalStorage: GoTrueLocalStorage, @unchecked Sendable {
   private let queue = DispatchQueue(label: "InMemoryLocalStorage")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

`signInWithIdToken` is currently marked as Experimental.

## What is the new behavior?

`signInWithIdToken` isn't Experimental anymore.